### PR TITLE
Fix Processing of Extensions Managed by `zokugun.vscode-vsix-manager`

### DIFF
--- a/src/repositories/file.ts
+++ b/src/repositories/file.ts
@@ -577,7 +577,7 @@ export class FileRepository extends Repository {
 
 	protected async listEditorUIStateProperties(userDataPath: string, extensions?: ExtensionList): Promise<Record<string, SqlValue>> { // {{{
 		if(!extensions) {
-			extensions = await this.listEditorExtensions([], false) ?? { disabled: [], enabled: [] };
+			extensions = await this.listEditorExtensions([], true) ?? { disabled: [], enabled: [] };
 		}
 
 		const keys = [

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -7,7 +7,7 @@ import { Settings } from './settings';
 import { exists } from './utils/exists';
 import { getExtensionDataPath } from './utils/get-extension-data-path';
 import { NIL_UUID } from './utils/nil-uuid';
-import { listManagedExtensions } from './utils/vsix-manager';
+import { listVSIXExtensions } from './utils/vsix-manager';
 
 export interface ExtensionId {
 	id: string;
@@ -53,8 +53,8 @@ export abstract class Repository {
 		return this._profile;
 	} // }}}
 
-	public async listEditorExtensions(ignoredExtensions: string[], ignoreManagedExtensions: boolean = true): Promise<ExtensionList> { // {{{
-		const managedExtensions = ignoreManagedExtensions ? await listManagedExtensions() : [];
+	public async listEditorExtensions(ignoredExtensions: string[], allInstalledExtensions: boolean = false): Promise<ExtensionList> { // {{{
+		const extensionsFromVSIXManager = allInstalledExtensions ? [] : await listVSIXExtensions();
 
 		const builtin: {
 			disabled: string[];
@@ -70,7 +70,7 @@ export abstract class Repository {
 			const id = extension.id;
 			const packageJSON = extension.packageJSON as { isBuiltin: boolean; isUnderDevelopment: boolean; uuid: string };
 
-			if(!packageJSON || packageJSON.isUnderDevelopment || id === this._settings.extensionId || ignoredExtensions.includes(id) || managedExtensions.includes(id)) {
+			if(!packageJSON || packageJSON.isUnderDevelopment || id === this._settings.extensionId || ignoredExtensions.includes(id) || extensionsFromVSIXManager.includes(id)) {
 				continue;
 			}
 
@@ -110,7 +110,7 @@ export abstract class Repository {
 				continue;
 			}
 
-			if(!ids[id] && id !== this._settings.extensionId && !ignoredExtensions.includes(id) && !managedExtensions.includes(id)) {
+			if(!ids[id] && id !== this._settings.extensionId && !ignoredExtensions.includes(id) && !extensionsFromVSIXManager.includes(id)) {
 				disabled.push({
 					id,
 					uuid: pkg.__metadata?.id ?? NIL_UUID,

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -54,7 +54,7 @@ export abstract class Repository {
 	} // }}}
 
 	public async listEditorExtensions(ignoredExtensions: string[], ignoreManagedExtensions: boolean = true): Promise<ExtensionList> { // {{{
-		const managedExtensions = ignoreManagedExtensions ? [] : await listManagedExtensions();
+		const managedExtensions = ignoreManagedExtensions ? await listManagedExtensions() : [];
 
 		const builtin: {
 			disabled: string[];

--- a/src/utils/vsix-manager.ts
+++ b/src/utils/vsix-manager.ts
@@ -15,7 +15,7 @@ export function getVSIXManager(): VSIXManager | undefined {
 	}
 }
 
-export async function listManagedExtensions(): Promise<string[]> {
+export async function listVSIXExtensions(): Promise<string[]> {
 	const vsixManager = getVSIXManager();
 
 	return await vsixManager?.listManagedExtensions() ?? [];

--- a/test/mocks/vscode.ts
+++ b/test/mocks/vscode.ts
@@ -17,6 +17,7 @@ interface Extension {
 const $executedCommands: string[] = [];
 const $extensions: string[] = [];
 let $manageExtensions = true;
+const $managedExtensions: string[] = [];
 const $outputLines: string[] = [];
 
 const $outputChannel = {
@@ -175,8 +176,8 @@ const $vscode = {
 			if(name === 'zokugun.vsix-manager') {
 				return {
 					exports: {
-						listManagedExtensions(): string[] {
-							return [];
+						listManagedExtensions() {
+							return $managedExtensions;
 						},
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						installExtensions() {},
@@ -317,6 +318,10 @@ function setManageExtensions(manage: boolean): void { // {{{
 	$manageExtensions = manage;
 } // }}}
 
+function setManagedExtensions(managedExtensions: string[]): void { // {{{
+	$managedExtensions.push(...managedExtensions);
+} // }}}
+
 function setPlatform(platform: string): void { // {{{
 	$platform = platform;
 } // }}}
@@ -369,6 +374,7 @@ export {
 	setExtensions,
 	setKeybindings,
 	setManageExtensions,
+	setManagedExtensions,
 	setPlatform,
 	setSettings,
 };

--- a/test/mocks/vscode.ts
+++ b/test/mocks/vscode.ts
@@ -297,7 +297,7 @@ function setKeybindings(data: string | any[]): void { // {{{
 	vol.writeFileSync('/user/keybindings.json', data, { encoding: 'utf-8' });
 } // }}}
 
-function setManagedExtensions(manage: boolean): void { // {{{
+function setManageExtensions(manage: boolean): void { // {{{
 	$manageExtensions = manage;
 } // }}}
 
@@ -352,7 +352,7 @@ export {
 	getExtensions,
 	setExtensions,
 	setKeybindings,
-	setManagedExtensions,
+	setManageExtensions,
 	setPlatform,
 	setSettings,
 };

--- a/test/mocks/vscode.ts
+++ b/test/mocks/vscode.ts
@@ -171,6 +171,22 @@ const $vscode = {
 	},
 	extensions: {
 		all: [] as Extension[],
+		getExtension(name: string) {
+			if(name === 'zokugun.vsix-manager') {
+				return {
+					exports: {
+						listManagedExtensions(): string[] {
+							return [];
+						},
+						// eslint-disable-next-line @typescript-eslint/no-empty-function
+						installExtensions() {},
+					},
+				};
+			}
+			else {
+				return null;
+			}
+		},
 	},
 	ProgressLocation: {
 		Notification: 0,

--- a/test/mocks/vscode.ts
+++ b/test/mocks/vscode.ts
@@ -355,6 +355,7 @@ function setSettings(data: any | string, { profile, hostname }: { profile: strin
 export function reset(): void { // {{{
 	$executedCommands.length = 0;
 	$extensions.length = 0;
+	$managedExtensions.length = 0;
 	$outputLines.length = 0;
 	$platform = 'linux';
 	$settings = {};

--- a/test/upload.lvl1.test.ts
+++ b/test/upload.lvl1.test.ts
@@ -299,6 +299,44 @@ describe('upload.lvl1', () => {
 				}));
 			}); // }}}
 		});
+
+		describe('managed-by-vsix-manager', () => {
+			const extensionName = 'pub1.ext1';
+
+			it('unmanaged', async () => { // {{{
+				vscode.setExtensions({
+					enabled: [extensionName],
+					disabled: [],
+				});
+
+				const repository = await RepositoryFactory.get();
+
+				await repository.upload();
+
+				expect(vol.readFileSync('/repository/profiles/level1/data/extensions.yml', 'utf-8')).to.eql(vscode.ext2yml({
+					disabled: [],
+					enabled: [extensionName],
+				}));
+			}); // }}}
+
+			it('managed', async () => { // {{{
+				vscode.setExtensions({
+					enabled: [extensionName],
+					disabled: [],
+				});
+
+				vscode.setManagedExtensions([extensionName]);
+
+				const repository = await RepositoryFactory.get();
+
+				await repository.upload();
+
+				expect(vol.readFileSync('/repository/profiles/level1/data/extensions.yml', 'utf-8')).to.eql(vscode.ext2yml({
+					disabled: [],
+					enabled: [],
+				}));
+			}); // }}}
+		});
 	});
 
 	describe('keybindings', () => {

--- a/test/upload.lvl1.test.ts
+++ b/test/upload.lvl1.test.ts
@@ -266,11 +266,11 @@ describe('upload.lvl1', () => {
 
 		describe('unmanaged', () => {
 			before(() => { // {{{
-				vscode.setManagedExtensions(false);
+				vscode.setManageExtensions(false);
 			});
 
 			after(() => { // {{{
-				vscode.setManagedExtensions(true);
+				vscode.setManageExtensions(true);
 			});
 
 			it('disabled', async () => { // {{{

--- a/test/upload.lvl1.test.ts
+++ b/test/upload.lvl1.test.ts
@@ -265,14 +265,6 @@ describe('upload.lvl1', () => {
 		});
 
 		describe('unmanaged', () => {
-			before(() => { // {{{
-				vscode.setManageExtensions(false);
-			});
-
-			after(() => { // {{{
-				vscode.setManageExtensions(true);
-			});
-
 			it('disabled', async () => { // {{{
 				vol.fromJSON({
 					'/repository/profiles/main/data/extensions.yml': vscode.ext2yml({
@@ -296,44 +288,6 @@ describe('upload.lvl1', () => {
 					disabled: [],
 					enabled: ['pub3.ext2'],
 					uninstall: ['pub1.ext3', 'pub3.ext1'],
-				}));
-			}); // }}}
-		});
-
-		describe('managed-by-vsix-manager', () => {
-			const extensionName = 'pub1.ext1';
-
-			it('unmanaged', async () => { // {{{
-				vscode.setExtensions({
-					enabled: [extensionName],
-					disabled: [],
-				});
-
-				const repository = await RepositoryFactory.get();
-
-				await repository.upload();
-
-				expect(vol.readFileSync('/repository/profiles/level1/data/extensions.yml', 'utf-8')).to.eql(vscode.ext2yml({
-					disabled: [],
-					enabled: [extensionName],
-				}));
-			}); // }}}
-
-			it('managed', async () => { // {{{
-				vscode.setExtensions({
-					enabled: [extensionName],
-					disabled: [],
-				});
-
-				vscode.setManagedExtensions([extensionName]);
-
-				const repository = await RepositoryFactory.get();
-
-				await repository.upload();
-
-				expect(vol.readFileSync('/repository/profiles/level1/data/extensions.yml', 'utf-8')).to.eql(vscode.ext2yml({
-					disabled: [],
-					enabled: [],
 				}));
 			}); // }}}
 		});

--- a/test/upload.test.ts
+++ b/test/upload.test.ts
@@ -446,4 +446,52 @@ describe('upload', () => {
 			expect(vol.readFileSync('/repository/profiles/main/data/snippets/loop.json', 'utf-8')).to.eql(snippetsFxt.json.loop);
 		}); // }}}
 	});
+
+	describe('vsix-manager', () => {
+		before(() => { // {{{
+			vscode.setManageExtensions(false);
+		});
+
+		after(() => { // {{{
+			vscode.setManageExtensions(true);
+		});
+
+		describe('upload', () => {
+			const extensionName = 'pub1.ext1';
+
+			it('unmanaged', async () => { // {{{
+				vscode.setExtensions({
+					enabled: [extensionName],
+					disabled: [],
+				});
+
+				const repository = await RepositoryFactory.get();
+
+				await repository.upload();
+
+				expect(vol.readFileSync('/repository/profiles/main/data/extensions.yml', 'utf-8')).to.eql(vscode.ext2yml({
+					disabled: [],
+					enabled: [extensionName],
+				}));
+			}); // }}}
+
+			it('managed', async () => { // {{{
+				vscode.setExtensions({
+					enabled: [extensionName],
+					disabled: [],
+				});
+
+				vscode.setManagedExtensions([extensionName]);
+
+				const repository = await RepositoryFactory.get();
+
+				await repository.upload();
+
+				expect(vol.readFileSync('/repository/profiles/main/data/extensions.yml', 'utf-8')).to.eql(vscode.ext2yml({
+					disabled: [],
+					enabled: [],
+				}));
+			}); // }}}
+		});
+	});
 });


### PR DESCRIPTION
Currently, extensions managed by `zokugun.vscode-vsix-manager` are sinced just like any other extension.

Changes made in this PR will cause extensions managed by `zokugun.vscode-vsix-manager` not to be synced.

Furthermore, tests were added to proof everything is working out as expected.

This PR is related to issue #32 