### PR TITLE
Include dot files like .sync.yml in push()

### DIFF
--- a/src/repositories/webdav.ts
+++ b/src/repositories/webdav.ts
@@ -248,6 +248,7 @@ export class WebDAVRepository extends FileRepository {
 		const files = await globby('**', {
 			cwd: path.join(this._rootPath, 'profiles'),
 			followSymbolicLinks: false,
+			dot: true // Include dot files like .sync.yml
 		});
 
 		const temporaryRoot = Uri.parse('/.profiles');


### PR DESCRIPTION
.sync.yml is currently excluded from push(), so when someone syncs from a repo, the syncSettings are missing.
For example, this can result in deletion of all extensions, if they were excluded in the repo with syncSettings.resources.