### PR TITLE
Fix Create new profile command

### DIFF
--- a/src/commands/create-profile.ts
+++ b/src/commands/create-profile.ts
@@ -15,7 +15,7 @@ export async function createProfile(): Promise<void> {
 			title: 'Create new profile',
 			placeHolder: 'New profile name',
 			validateInput(value) {
-				const correct = value.replaceAll(/[^\w\-.]/, '');
+				const correct = value.replaceAll(/[^\w\-.]/g, '');
 				if(correct === value) {
 					return null;
 				}


### PR DESCRIPTION
This resolves the issue #85 by adding the global flag to the replace regex.

While this doesn't fix it from silently failing, it does allow the user to proceed and actually create new profiles