### PR TITLE
fix: sort extensionslist before uploading

### DIFF
--- a/src/utils/sort-extension-list.ts
+++ b/src/utils/sort-extension-list.ts
@@ -1,15 +1,12 @@
 import type { ExtensionList, ExtensionId } from '../repository.js';
 
-export function sortExtensionsById(list: ExtensionId[]): ExtensionId[] {
-	return list.sort((a, b) => a.id.localeCompare(b.id));
-}
-
 /**
  * Sorts an ExtensionList by extension IDs in ascending order.
  * Does not mutate the original ExtensionList; returns a new sorted instance.
  */
 export function sortExtensionList(extensionList: ExtensionList): ExtensionList {
 	const cloned = structuredClone(extensionList);
+
 	if(cloned.builtin) {
 		cloned.builtin.disabled &&= cloned.builtin.disabled.sort((a, b) => a.localeCompare(b));
 		cloned.builtin.enabled &&= cloned.builtin.enabled.sort((a, b) => a.localeCompare(b));
@@ -18,5 +15,10 @@ export function sortExtensionList(extensionList: ExtensionList): ExtensionList {
 	cloned.disabled = sortExtensionsById(cloned.disabled);
 	cloned.enabled = sortExtensionsById(cloned.enabled);
 	cloned.uninstall &&= sortExtensionsById(cloned.uninstall);
+
 	return cloned;
+}
+
+function sortExtensionsById(list: ExtensionId[]): ExtensionId[] {
+	return list.sort((a, b) => a.id.localeCompare(b.id));
 }


### PR DESCRIPTION
mildly related to https://github.com/zokugun/vscode-sync-settings/issues/43

## Background

I would like to use this extension to basically write to my symlinked dotfiles. the order of the extensions list keeps changing, so I propose just sorting the whole ExtensionsList object so that the output is stable