### PR TITLE
Prevent error when Cursor IDE need restarting

### DIFF
--- a/src/repositories/file.ts
+++ b/src/repositories/file.ts
@@ -16,7 +16,7 @@ import { Hook, Settings } from '../settings.js';
 import { arrayDiff } from '../utils/array-diff.js';
 import { EXTENSION_NAME } from '../utils/constants.js';
 import { disableExtension } from '../utils/disable-extension.js';
-import { EDITOR_MODE, EditorMode } from '../utils/editor.js';
+import { EDITOR_MODE, EditorMode, isVSCodeCompatible } from '../utils/editor.js';
 import { enableExtension } from '../utils/enable-extension.js';
 import { exists } from '../utils/exists.js';
 import { extractProperties } from '../utils/extract-properties.js';
@@ -392,7 +392,7 @@ export class FileRepository extends Repository {
 				await this.restoreTasks(userDataPath);
 			}
 
-			if(EDITOR_MODE === EditorMode.VSCode) {
+			if(isVSCodeCompatible()) {
 				if(resources.includes(Resource.Mcp)) {
 					await this.restoreMcp(userDataPath);
 				}
@@ -458,7 +458,7 @@ export class FileRepository extends Repository {
 		}
 
 		if(!this._settings.remote) {
-			if(EDITOR_MODE === EditorMode.VSCode) {
+			if(isVSCodeCompatible()) {
 				if(resources.includes(Resource.Snippets)) {
 					await this.serializeSnippets(profileSettings, userDataPath);
 				}
@@ -496,7 +496,7 @@ export class FileRepository extends Repository {
 					await this.scrubTasks();
 				}
 
-				if(EDITOR_MODE === EditorMode.VSCode) {
+				if(isVSCodeCompatible()) {
 					if(resources.includes(Resource.Mcp)) {
 						await this.serializeMcp(syncSettings, userDataPath);
 					}
@@ -1854,7 +1854,7 @@ export class FileRepository extends Repository {
 			return true;
 		}
 
-		if(EDITOR_MODE === EditorMode.VSCode) {
+		if(isVSCodeCompatible()) {
 			const editor = await this.listEditorUIStateProperties(userDataPath, extensions);
 			const profile = await this.listProfileUIStateProperties();
 

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -1,14 +1,19 @@
 import path from 'path';
 import process from 'process';
-import type vscode from 'vscode';
+import vscode from 'vscode';
 
 export enum EditorMode {
+	Cursor = 'cursor',
 	Theia = 'theia',
 	VSCode = 'vscode',
 }
 
 // eslint-disable-next-line import/no-mutable-exports,@typescript-eslint/naming-convention
 export let EDITOR_MODE = EditorMode.VSCode;
+
+export function isVSCodeCompatible(): boolean {
+	return EDITOR_MODE === EditorMode.VSCode || EDITOR_MODE === EditorMode.Cursor;
+}
 
 export function detectEditor(context: vscode.ExtensionContext): void {
 	if(process.env.VSCODE_PORTABLE) {
@@ -19,5 +24,8 @@ export function detectEditor(context: vscode.ExtensionContext): void {
 
 	if(path.basename(storage) !== 'User') {
 		EDITOR_MODE = EditorMode.Theia;
+	}
+	else if(vscode.env.appName.includes('Cursor')) {
+		EDITOR_MODE = EditorMode.Cursor;
 	}
 }

--- a/src/utils/restart.ts
+++ b/src/utils/restart.ts
@@ -35,7 +35,7 @@ export async function restartEditor(restart: boolean, reload: boolean, mode: Res
 }
 
 async function doRestart(name: string): Promise<void> {
-	if(EDITOR_MODE === EditorMode.Theia) {
+	if(EDITOR_MODE === EditorMode.Theia || EDITOR_MODE === EditorMode.Cursor) {
 		await vscode.window.showInformationMessage(
 			`Source: ${name}\n\nThe editor needs to be restarted before continuing. You need to do it manually. Thx`,
 			{


### PR DESCRIPTION
## Summary

On [Cursor IDE](https://cursor.com/) I have the following error when editor must be restarted:

<img width="1545" height="103" alt="image" src="https://github.com/user-attachments/assets/4d2120a4-37a0-4a1d-b6bf-df52129c13b7" />

I made this PR to add Cursor IDE support alongside the existing VSCode and Eclipse Theia editors.

## Changes

- Added `Cursor` variant to the `EditorMode` enum
- Cursor is detected via `vscode.env.appName` in `detectEditor()`
- Added `isVSCodeCompatible()` helper function that returns `true` for both VSCode and Cursor, since Cursor is a VSCode fork and supports the same features
- Updated all `EDITOR_MODE === EditorMode.VSCode` checks in `src/repositories/file.ts` to use `isVSCodeCompatible()`, enabling VSCode-only resources (snippets, UI state, MCP, profiles) for Cursor users
- Files checking `=== EditorMode.Theia` with an else branch (`get-editor-storage.ts`, `restart.ts`, `repository.ts`) were left unchanged as Cursor already falls into the VSCode-compatible else path