### PR TITLE
Make `README` more semantic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,24 @@ Sync Settings
 [![Liberapay](https://img.shields.io/badge/donate-liberapay-green)](https://liberapay.com/daiyam/donate)
 [![Paypal](https://img.shields.io/badge/donate-paypal-green)](https://paypal.me/daiyam99)
 
-With [Sync Settings](https://github.com/zokugun/vscode-sync-settings), you can synchronize your settings/resources across multiple devices.<br />
-You can also switch between profiles with their own settings/resources.
-It supports with Visual Studio Code, Eclipse Theia, and other Theia/VSCode derivatives.
+With [Sync Settings](https://github.com/zokugun/vscode-sync-settings), you can synchronize your settings/resources across multiple devices.
+
+You can also switch between profiles with their own settings/resources. It supports with Visual Studio Code, Eclipse Theia, and other Theia/VSCode derivatives.
 
 HowTo
 -----
 
 1. configure the repository:
 
-   > &gt; Sync Settings: Open the repository settings
+   > \> Sync Settings: Open the repository settings
 
 2. upload your settings to the repository:
-    > &gt; Sync Settings: Upload (user -> repository)
 
-3. download your settings into a new editor:
-    > &gt; Sync Settings: Download (repository -> user)
+    > \> Sync Settings: Upload (user -> repository)
+
+4. download your settings into a new editor:
+
+    > \> Sync Settings: Download (repository -> user)
 
 Configuration
 -------------
@@ -34,7 +36,7 @@ The repository is configured with the following file:
 
 ##### `settings.yml`
 
-```yaml
+```YAML
 # current machine's name, optional; it can be used to filter settings or in the commit message
 hostname: ""
 # more details at https://github.com/zokugun/vscode-sync-settings/blob/master/docs/hostname.md
@@ -49,13 +51,13 @@ repository:
 
 You can open that file with the command:
 
-> &gt; Sync Settings: Open the repository settings
+> \> Sync Settings: Open the repository settings
 
 ### Repository types
 
-#### file
+#### File
 
-```yaml
+```YAML
 # sync on local file system
 repository:
   type: file
@@ -63,9 +65,9 @@ repository:
   path: ~/Development/settings
 ```
 
-#### local git
+#### Local Git
 
-```yaml
+```YAML
 # sync on local git
 repository:
   type: git
@@ -79,9 +81,9 @@ If not initialized, the git repository will be automatically initialized.
 
 [How to personalize the commit messages](https://github.com/zokugun/vscode-sync-settings/blob/master/docs/commit-messages.md)
 
-#### remote git
+#### Remote Git
 
-```yaml
+```YAML
 # sync on remote git
 repository:
   type: git
@@ -91,14 +93,15 @@ repository:
   branch: master
 ```
 
-No authentifications are stored.<br/>
+No authentifications are stored.
+
 But the `git` command on your system will need to be able to read/write on the remote repository.
 
 [How to personalize the commit messages](https://github.com/zokugun/vscode-sync-settings/blob/master/docs/commit-messages.md)
 
-#### rsync
+#### `rsync`
 
-```yaml
+```YAML
 # sync on remote directory with rsync
 repository:
   type: rsync
@@ -110,9 +113,9 @@ repository:
 
 The access to the server shouldn't require the need of any passwords.
 
-#### webdav
+#### WebDAV
 
-```yaml
+```YAML
 # sync on remote directory with webdav
 repository:
   type: webdav
@@ -129,19 +132,30 @@ repository:
 
 ### Which resources?
 
-You can configure what and how to synchronize with properties in your regular settings (`settings.json`).
+You can configure what and how to synchronize with properties in your regular settings (`settings.json`):
 
-- `"syncSettings.resources": ["extensions", "keybindings", "settings", "snippets", "tasks", "uiState"]`
-- `"syncSettings.ignoredExtensions": ["<extension's id>"]`
-- `"syncSettings.ignoredSettings": ["editor.fontFamily"]`
-- `"syncSettings.keybindingsPerPlatform": true`
+- ```JSON
+  "syncSettings.resources": ["extensions", "keybindings", "settings", "snippets", "tasks", "uiState"]
+  ```
+
+- ```JSON
+  "syncSettings.ignoredExtensions": ["<extension's id>"]
+  ```
+
+- ```JSON
+  "syncSettings.ignoredSettings": ["editor.fontFamily"]
+  ```
+
+- ```JSON
+  "syncSettings.keybindingsPerPlatform": true
+  ```
 
 External Files
 --------------
 
 Additionally, you can sync external files with the following property in your regular settings (`settings.json`):
 
-```json
+```JSON
 "syncSettings.additionalFiles": [
     "~globalStorage/alefragnani.project-manager/projects.json",
     "~/vscode_projects.json",
@@ -149,8 +163,11 @@ Additionally, you can sync external files with the following property in your re
 ```
 
 The paths can start with special prefixes:
+
 - `~/`: the user home (as usual)
+
 - `~editorStorage`: the directory where the extensions are stored (ex: `~/.vscode`)
+
 - `~globalStorage`: the directory where the extensions are storing their global states (ex: `~/Library/ApplicationSupport/Code/User/globalStorage`)
 
 #### `settings.yml`
@@ -162,7 +179,7 @@ There is no need to synchronize that file since it contains only the needed and 
 Saved Extensions
 ----------------
 
-When installing an extension, if a matching `.vsix` is present in the `data/extensions` directory of the profile, that `.vsix` will installed instead of the one found in the marketplace.
+When installing an extension, if a matching `.VSIX` is present in the `data/extensions` directory of the profile, that `.VSIX` will installed instead of the one found in the marketplace.
 
 You can find the `data/extensions` directory by executing the command `> Sync Settings: Reveal the profile in the file explorer`.
 
@@ -171,33 +188,49 @@ Profiles
 
 Each profile has its own directory in the repository and can be configured independently of each other.
 
-You can create a new profile with the command `> Sync Settings: Create a new profile`.<br />
+You can create a new profile with the command `> Sync Settings: Create a new profile`.
+
 Or switch to an existing one with the command `> Sync Settings: Switch to profile`.
 
 ### Profile Inheritance
 
 A profile can extend an existing profile but it's limited to the following resources:
+
 - extensions
+
 - snippets
 
-You can select the profile to extend from when creating a new profile (command `> Sync Settings: Create a new profile`).<br />
+You can select the profile to extend from when creating a new profile (command `> Sync Settings: Create a new profile`).
+
 The command `> Sync Settings: Open the profile settings` will allow you to modify the property `extends`.
 
 Commands
 --------
 
 - `> Sync Settings: Open the repository settings`: open the settings for configuring the repository
+
 - `> Sync Settings: Upload (user -> repository)`: upload/copy the resources from the user to the repository
+
 - `> Sync Settings: Download (repository -> user)`: download/copy the resources from the repository to the user
+
 - `> Sync Settings: View differences between actual and saved settings`: display differences between the actual settings and the saved ones
+
 - `> Sync Settings: Prompt if a difference between actual and saved settings is been found`: prompt if you want to upload your settings if any difference has been found
+
 - `> Sync Settings: List the missing extensions`: display the list of missing extensions
+
 - `> Sync Settings: Create a new profile`: create a new profile
+
 - `> Sync Settings: Delete a profile`: delete a profile
+
 - `> Sync Settings: Switch to profile`: switch to the selected profile
+
 - `> Sync Settings: Open the profile settings`: open the settings for configuring the profile
+
 - `> Sync Settings: Reveal the profile in the file explorer`: open the profile's local copy in the file explorer
+
 - `> Sync Settings: Reveal the repository in the file explorer`: open the repository's local copy in the file explorer
+
 - `> Sync Settings: Remove all settings and extensions`: ⚠️⚠️ remove all your local resources ⚠️⚠️
 
 JSONC Attributes
@@ -207,7 +240,7 @@ JSONC attributes can be used to enable/disable settings based on, for example, t
 
 ### example
 
-```
+```JSONC
 {
     // #if(os="mac")
     // "editor.fontWeight": "300",
@@ -222,18 +255,20 @@ JSONC attributes can be used to enable/disable settings based on, for example, t
 When the `settings.json` is downloaded, depending on the OS, the setting `editor.fontWeight` will have the following value:
 
 | OS      | `editor.fontWeight` |
-| ------- |:-------------------:|
-| Linux   |        `500`        |
-| MacOS   |        `300`        |
-| Windows |        `400`        |
+|---------|--------------------:|
+| Linux   |               `500` |
+| MacOS   |               `300` |
+| Windows |               `400` |
 
 [More details here](https://github.com/zokugun/vscode-sync-settings/blob/master/docs/attributes.md)
 
 Hooks
 -----
 
-Hooks allow you to run commands in an integrated terminal ***before*** and ***after*** the following events:
+Hooks allow you to run commands in an integrated terminal <em>before</em> and <em>after</em> the following events:
+
 - `download`
+
 - `upload`
 
 [More details here](https://github.com/zokugun/vscode-sync-settings/blob/master/docs/hooks.md)
@@ -256,15 +291,19 @@ Eclipse Theia
 -------------
 
 Support for Eclipse Theia is limited to:
+
 - settings
+
 - keyboard shortcuts
+
 - tasks
+
 - additional files
 
 Donations
 ---------
 
-Support this project by becoming a financial contributor.
+Support this project by becoming a financial contributor:
 
 <table>
     <tr>


### PR DESCRIPTION
They're all very minor modifications:

- All inaccessible `<br/>`s (and the occasional, inconsistent usage of `<br />`s) have been replaced by real `p`s, so that they wrap as expected, and screen readers announce them.

- `&gt;` has been replaced by `\>`, so that it is more readable as `text/plain`.

- The JSONC `pre > code` has had syntax highlighting enabled.

- Some headings that erroneously lacked title case now utilise it (like “WebDAV”), and `rsync` has been codified.

- Eastern Arabic numerals should be right-aligned, rather than centred (like Mandarin), so they have been.

- `:is(ul, ol) li`s should always be spaced with a `\n`, else they do not wrap with a gap. This means that they'll appear different to your `p`s. Refer to the CommonMark (and GHFM) standards.

- The JSON examples are block elements, so that they can be syntax-highlighted and easily duplicated into the clipboard.

In case this matters, because it appears to be a scourge nowadays, no LLMs were involved in this process whatsoever. Not that they'd need to be; it's mere markup.