### PR TITLE
fix: ids from `extensions.json` and `.obsolete` are lowercase

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -248,9 +248,11 @@ export abstract class Repository {
 
 		const extensionDataPath = await getExtensionDataPath();
 
+		// id: lowercase
 		const obsoletePath = path.join(extensionDataPath, '.obsolete');
 		const obsolete = await exists(obsoletePath) ? await fse.readJSON(obsoletePath) as Record<string, boolean> : {};
 
+		// id: lowercase
 		const extensionsJsonPath = path.join(extensionDataPath, 'extensions.json');
 		const extensionsJson = await exists(extensionsJsonPath) ? await fse.readJSON(extensionsJsonPath) as Array<{ identifier: { id: string; uuid: string }; metadata: { pinned?: boolean; source: string; id: string }; version: string }> : [];
 		const metadatas: Record<string, { uuid: string; pinned: boolean; source: string; version: string; metadataId: string }> = {};
@@ -277,12 +279,13 @@ export abstract class Repository {
 
 			const pkg = await fse.readJSON(path.join(extensionDataPath, packagePath)) as { name: string; publisher: string; __metadata: { id: string } };
 			const id = `${pkg.publisher}.${pkg.name}`;
+			const idLower = id.toLowerCase();
 
-			if(obsolete[id]) {
+			if(obsolete[idLower]) {
 				continue;
 			}
 
-			const version = metadatas[id]?.pinned && metadatas[id].source === 'gallery' ? metadatas[id].version : undefined;
+			const version = metadatas[idLower]?.pinned && metadatas[idLower].source === 'gallery' ? metadatas[idLower].version : undefined;
 
 			if(ids[id]) {
 				if(version) {
@@ -299,8 +302,8 @@ export abstract class Repository {
 				if(pkg.__metadata?.id) {
 					uuid = pkg.__metadata?.id;
 				}
-				else if(metadatas[id]) {
-					uuid = metadatas[id].uuid ?? metadatas[id].metadataId ?? NIL_UUID;
+				else if(metadatas[idLower]) {
+					uuid = metadatas[idLower].uuid ?? metadatas[idLower].metadataId ?? NIL_UUID;
 				}
 
 				const extension: { id: string; uuid: string; version?: string } = {

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -169,7 +169,7 @@ export abstract class Repository {
 		for(const packagePath of extensions) {
 			const name = path.dirname(path.dirname(packagePath));
 
-			if(!/^.*?-\d+\.\d+\.\d+(?:-|$)/.test(name)) {
+			if(!/^.*?-\d+\.\d+\.\d+/.test(name)) {
 				continue;
 			}
 
@@ -267,8 +267,12 @@ export abstract class Repository {
 		for(const packagePath of extensions) {
 			const name = path.dirname(packagePath);
 
-			const match = /^(.*?-\d+\.\d+\.\d+)(?:-|$)/.exec(name);
-			if(!match || obsolete[match[1]]) {
+			// `.obsolete` contains the directory name of the obsolete extensions
+			if(obsolete[name]) {
+				continue;
+			}
+
+			if(!/^.*?-\d+\.\d+\.\d+/.test(name)) {
 				continue;
 			}
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -169,8 +169,7 @@ export abstract class Repository {
 		for(const packagePath of extensions) {
 			const name = path.dirname(path.dirname(packagePath));
 
-			const match = /^(.*?)-\d+\.\d+\.\d+(?:-|$)/.exec(name);
-			if(!match) {
+			if(!/^.*?-\d+\.\d+\.\d+(?:-|$)/.test(name)) {
 				continue;
 			}
 
@@ -268,23 +267,14 @@ export abstract class Repository {
 		for(const packagePath of extensions) {
 			const name = path.dirname(packagePath);
 
-			if(obsolete[name]) {
-				continue;
-			}
-
-			const match = /^(.*?)-\d+\.\d+\.\d+(?:-|$)/.exec(name);
-			if(!match) {
+			const match = /^(.*?-\d+\.\d+\.\d+)(?:-|$)/.exec(name);
+			if(!match || obsolete[match[1]]) {
 				continue;
 			}
 
 			const pkg = await fse.readJSON(path.join(extensionDataPath, packagePath)) as { name: string; publisher: string; __metadata: { id: string } };
 			const id = `${pkg.publisher}.${pkg.name}`;
 			const idLower = id.toLowerCase();
-
-			if(obsolete[idLower]) {
-				continue;
-			}
-
 			const version = metadatas[idLower]?.pinned && metadatas[idLower].source === 'gallery' ? metadatas[idLower].version : undefined;
 
 			if(ids[id]) {


### PR DESCRIPTION
This PR correctly read the version of an extension for those which have an id containing uppercase letters. 

References:
- #143